### PR TITLE
Add packet logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ pgbouncer_SOURCES = \
 	src/hba.c \
 	src/janitor.c \
 	src/loader.c \
+	src/logging.c \
 	src/main.c \
 	src/objects.c \
 	src/pam.c \
@@ -37,6 +38,7 @@ pgbouncer_SOURCES = \
 	include/iobuf.h \
 	include/janitor.h \
 	include/loader.h \
+	include/logging.h \
 	include/objects.h \
 	include/pam.h \
 	include/pktbuf.h \

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -227,6 +227,12 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; Logging verbosity.  Same as -v switch on command line.
 ;verbose = 0
 
+;; Log incoming client packets
+;; Will decrease throughput by at least 15%, depending on disk speed.
+;; Useful for mirroring traffic.
+;log_packets = 0
+;log_packets_file = /tmp/pktlog
+
 ;;;
 ;;; Timeouts
 ;;;

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -368,6 +368,7 @@ struct PgDatabase {
  * ->state corresponds to various lists the struct can be at.
  */
 struct PgSocket {
+	uint32_t client_id; /* A "unique" id of the client */
 	struct List head;		/* list header */
 	PgSocket *link;		/* the dest of packets */
 	PgPool *pool;		/* parent pool, if NULL not yet assigned */

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -528,6 +528,7 @@ extern int cf_tcp_user_timeout;
 
 extern int cf_log_connections;
 extern int cf_log_packets;
+extern char *cf_log_packets_file;
 extern int cf_log_disconnections;
 extern int cf_log_pooler_errors;
 extern int cf_application_name_add_host;

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -122,6 +122,7 @@ extern int cf_sbuf_len;
 #include "janitor.h"
 #include "hba.h"
 #include "pam.h"
+#include "logging.h"
 
 #ifndef WIN32
 #define DEFAULT_UNIX_SOCKET_DIR "/tmp"
@@ -526,6 +527,7 @@ extern int cf_tcp_defer_accept;
 extern int cf_tcp_user_timeout;
 
 extern int cf_log_connections;
+extern int cf_log_packets;
 extern int cf_log_disconnections;
 extern int cf_log_pooler_errors;
 extern int cf_application_name_add_host;

--- a/include/logging.h
+++ b/include/logging.h
@@ -1,0 +1,17 @@
+/*
+ * PgBouncer - Lightweight connection pooler for PostgreSQL.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+static void log_client_pkt(PktHdr *pkt, const char *fname);

--- a/include/logging.h
+++ b/include/logging.h
@@ -16,4 +16,4 @@
 
 void log_shutdown(void);
 void log_init(void);
-void log_pkt_to_buffer(PktHdr*);
+void log_pkt_to_buffer(PktHdr *pkt, PgSocket *client);

--- a/include/logging.h
+++ b/include/logging.h
@@ -14,4 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-static void log_client_pkt(PktHdr *pkt, const char *fname);
+void log_client_pkt_cb(evutil_socket_t fd, short flags, void *arg);
+void log_client_pkt(PgSocket *client, PktHdr *pkt, const char *fname);
+void log_shutdown(void);
+void log_init(void);
+void log_pkt_to_buffer(PktHdr*);

--- a/include/logging.h
+++ b/include/logging.h
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-void log_client_pkt_cb(evutil_socket_t fd, short flags, void *arg);
-void log_client_pkt(PgSocket *client, PktHdr *pkt, const char *fname);
 void log_shutdown(void);
 void log_init(void);
 void log_pkt_to_buffer(PktHdr*);

--- a/src/client.c
+++ b/src/client.c
@@ -852,7 +852,6 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 {
 	SBuf *sbuf = &client->sbuf;
 	int rfq_delta = 0;
-	bool log = true;
 
 	switch (pkt->type) {
 
@@ -872,7 +871,6 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 	/* request immediate response from server */
 	case 'S':		/* Sync */
 		rfq_delta++;
-		log = false;
 		break;
 	case 'H':		/* Flush */
 		break;
@@ -938,8 +936,8 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 	sbuf_prepare_send(sbuf, &client->link->sbuf, pkt->len);
 
 	/* log the query, if needed */
-	if (log) {
-		log_client_pkt(pkt, "/tmp/pktlog");
+	if (cf_log_packets) {
+		log_pkt_to_buffer(pkt);
 	}
 
 	return true;

--- a/src/client.c
+++ b/src/client.c
@@ -23,6 +23,7 @@
 #include "bouncer.h"
 #include "pam.h"
 #include "scram.h"
+#include "logging.h"
 
 #include <usual/pgutil.h>
 
@@ -851,6 +852,7 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 {
 	SBuf *sbuf = &client->sbuf;
 	int rfq_delta = 0;
+	bool log = true;
 
 	switch (pkt->type) {
 
@@ -870,6 +872,7 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 	/* request immediate response from server */
 	case 'S':		/* Sync */
 		rfq_delta++;
+		log = false;
 		break;
 	case 'H':		/* Flush */
 		break;
@@ -933,6 +936,11 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 
 	/* forward the packet */
 	sbuf_prepare_send(sbuf, &client->link->sbuf, pkt->len);
+
+	/* log the query, if needed */
+	if (log) {
+		log_client_pkt(pkt, "/tmp/pktlog");
+	}
 
 	return true;
 }

--- a/src/client.c
+++ b/src/client.c
@@ -937,7 +937,7 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 
 	/* log the query, if needed */
 	if (cf_log_packets)
-		log_pkt_to_buffer(pkt);
+		log_pkt_to_buffer(pkt, client);
 
 	return true;
 }

--- a/src/client.c
+++ b/src/client.c
@@ -936,9 +936,8 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 	sbuf_prepare_send(sbuf, &client->link->sbuf, pkt->len);
 
 	/* log the query, if needed */
-	if (cf_log_packets) {
+	if (cf_log_packets)
 		log_pkt_to_buffer(pkt);
-	}
 
 	return true;
 }

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -655,6 +655,8 @@ static void do_full_maint(evutil_socket_t sock, short flags, void *arg)
 		log_info("server connections dropped, exiting");
 		cf_shutdown = 2;
 		event_base_loopbreak(pgb_event_base);
+		if (cf_log_packets)
+			log_shutdown();
 		return;
 	}
 

--- a/src/logging.c
+++ b/src/logging.c
@@ -1,0 +1,47 @@
+/*
+ * PgBouncer - Lightweight connection pooler for PostgreSQL.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * Query logging
+ */
+
+#include "bouncer.h"
+#include <sys/file.h>
+
+/* log a client packet to a file */
+void log_client_pkt(PktHdr *pkt, const char *fname)
+{
+  int tmp_fd, fd;
+  char tmp_fname[strlen(fname)+5];
+  char pkt_sep[] = {'\x19'};
+  snprintf(tmp_fname, strlen(fname) + 6, "%s.lock", fname);
+
+  /* acquire a lock on our lock file */
+  tmp_fd = open(tmp_fname, O_CREAT | O_EXLOCK, S_IWUSR | S_IRUSR);
+
+  /* open our log file append only */
+  fd = open(fname, O_APPEND | O_CREAT | O_WRONLY, S_IWUSR | S_IRUSR);
+
+  /* write the packet; the data includes the packet type */
+  write(fd, pkt->data.data, pkt->len);
+  /* write out packet separator */
+  write(fd, &pkt_sep, 1);
+
+  /* close our file and release the lock */
+  fsync(fd);
+  close(fd);
+  close(tmp_fd);
+}

--- a/src/logging.c
+++ b/src/logging.c
@@ -25,7 +25,7 @@
 void log_client_pkt(PktHdr *pkt, const char *fname)
 {
   int tmp_fd, fd;
-  char tmp_fname[strlen(fname)+5];
+  char tmp_fname[strlen(fname)+6];
   char pkt_sep[] = {'\x19'};
   snprintf(tmp_fname, strlen(fname) + 6, "%s.lock", fname);
 

--- a/src/logging.c
+++ b/src/logging.c
@@ -21,7 +21,6 @@
 #include "bouncer.h"
 
 #include <sys/file.h>
-#include <usual/psrandom.h>
 #include <errno.h>
 
 #define LOG_BUFFER_SIZE 1024 * 1024 /* 1 MB */

--- a/src/logging.c
+++ b/src/logging.c
@@ -24,7 +24,7 @@
 #define LOG_BUFFER_SIZE 1024 * 1024 /* 1 MB */
 #define MAX_LOG_FILE_SIZE 1024 * 1024 * 25 /* 25 MB; if we get this far, the replayer isn't doing its job */
 
-/* do full maintenance 10x per second */
+/* Flush packets to log every 0.1 of a second */
 static struct timeval buffer_drain_period = {0, USEC / 10};
 static struct event buffer_drain_ev;
 

--- a/src/main.c
+++ b/src/main.c
@@ -159,6 +159,7 @@ int cf_log_connections;
 int cf_log_disconnections;
 int cf_log_pooler_errors;
 int cf_application_name_add_host;
+int cf_log_packets;
 
 int cf_client_tls_sslmode;
 char *cf_client_tls_protocols;
@@ -292,6 +293,7 @@ CF_ABS("stats_users", CF_STR, cf_stats_users, 0, ""),
 CF_ABS("stats_period", CF_INT, cf_stats_period, 0, "60"),
 CF_ABS("log_stats", CF_INT, cf_log_stats, 0, "1"),
 CF_ABS("log_connections", CF_INT, cf_log_connections, 0, "1"),
+CF_ABS("log_packets", CF_INT, cf_log_packets, 0, "0"),
 CF_ABS("log_disconnections", CF_INT, cf_log_disconnections, 0, "1"),
 CF_ABS("log_pooler_errors", CF_INT, cf_log_pooler_errors, 0, "1"),
 CF_ABS("application_name_add_host", CF_INT, cf_application_name_add_host, 0, "0"),
@@ -808,6 +810,7 @@ static void cleanup(void)
 	pktbuf_cleanup();
 
 	reset_logging();
+	log_shutdown();
 
 	xfree(&cf_username);
 	xfree(&cf_config_file);
@@ -959,6 +962,8 @@ int main(int argc, char *argv[])
 	dns_setup();
 	signal_setup();
 	janitor_setup();
+	if (cf_log_packets)
+		log_init();
 	stats_setup();
 
 	pam_init();

--- a/src/main.c
+++ b/src/main.c
@@ -160,6 +160,7 @@ int cf_log_disconnections;
 int cf_log_pooler_errors;
 int cf_application_name_add_host;
 int cf_log_packets;
+char *cf_log_packets_file;
 
 int cf_client_tls_sslmode;
 char *cf_client_tls_protocols;
@@ -294,6 +295,7 @@ CF_ABS("stats_period", CF_INT, cf_stats_period, 0, "60"),
 CF_ABS("log_stats", CF_INT, cf_log_stats, 0, "1"),
 CF_ABS("log_connections", CF_INT, cf_log_connections, 0, "1"),
 CF_ABS("log_packets", CF_INT, cf_log_packets, 0, "0"),
+CF_ABS("log_packets_file", CF_STR, cf_log_packets_file, 0, "/tmp/pktlog"),
 CF_ABS("log_disconnections", CF_INT, cf_log_disconnections, 0, "1"),
 CF_ABS("log_pooler_errors", CF_INT, cf_log_pooler_errors, 0, "1"),
 CF_ABS("application_name_add_host", CF_INT, cf_application_name_add_host, 0, "0"),

--- a/src/main.c
+++ b/src/main.c
@@ -812,7 +812,8 @@ static void cleanup(void)
 	pktbuf_cleanup();
 
 	reset_logging();
-	log_shutdown();
+	if (cf_log_packets)
+		log_shutdown();
 
 	xfree(&cf_username);
 	xfree(&cf_config_file);

--- a/src/objects.c
+++ b/src/objects.c
@@ -64,6 +64,11 @@ static STATLIST(justfree_server_list);
 /* init autodb idle list */
 STATLIST(autodatabase_idle_list);
 
+/*
+ * Count clients that are coming in to give them "unique" ids.
+ */
+static uint32_t client_ids = 0;
+
 /* fast way to get number of active clients */
 int get_active_client_count(void)
 {
@@ -1237,6 +1242,7 @@ PgSocket *accept_client(int sock, bool is_unix)
 
 	client->connect_time = client->request_time = get_cached_time();
 	client->query_start = 0;
+	client->client_id = ++client_ids;
 
 	/* FIXME: take local and remote address from pool_accept() */
 	fill_remote_addr(client, sock, is_unix);


### PR DESCRIPTION
### Summary
Give PgBouncer the ability to log incoming client packets to a log file. The packets can then be picked up by another tool to either analyze them or replay traffic. The implementation is best effort and does not guarantee accurate packet logging in an attempt to preserve PgBouncer primary performance goals.

### Implementation
The packets are placed into a memory buffer before being flushed to the log file. The buffer is 1MB. Every 0.1 seconds, the buffer is flushed to disk.

Before flushing, an advisory shared lock is acquired on the `<log_packets_file>.lock`. A cooperating application should acquire an advisory exclusive lock on that same file in order to perform log file rotation; log file corruption can happen otherwise. That application should quickly rotate the log file and release the lock. PgBouncer will not wait on the lock and will postpone packet flushing until the next iteration of the event loop if the lock cannot be acquired. The packets will no longer be logged if the buffer gets full.

If the log file is larger than 25MB, the buffer will not be flushed and packet logging will stop once the buffer fills up. This is to protect against uncooperative applications that do not rotate the log file often enough.

Supported packets are:
- `P` - prepared statement
- `B` - bind parameters to the prepared statement
- `E` - execute the prepared statement with bound parameters
- `Q` - simple query execute, with supplied parameters

The implementation supports both extended and simple Postgres query protocols. Copy is intentionally ignored, since it provides no useful benchmarking features & can saturate the log file very quickly.

### Performance implications
Using pgBench, this reduced the TPS (transactions per second) by about 15-20 percent. This is expected, since PgBouncer is single-threaded & the log file flushing is synchronous.

### Benchmark
Using pgBench: `pgbench -c 16 -j 4 -t 1000 -p 6432 -U tester -h 127.0.0.1 -d postgres --protocol=extended`

```
#
# TPS without packet logging
#
tps = 2226.668526 (including connections establishing)
tps = 2226.832039 (excluding connections establishing)

#
# TPS with packet logging
#
tps = 1976.224122 (including connections establishing)
tps = 1976.372030 (excluding connections establishing)

#
# Performance penalty: 13%
#
```

### Testing protocol
- [x] Tested locally to make sure the implementation is workable
- [ ] Tested staging to try this under moderate organic load
- [ ] Deploy to a selected production service with low traffic to test low/moderate production load
- [ ] Deploy to a bigger production service with moderate to high traffic to test moderate/high production load