### PR TITLE
remove file locking, use (0-255) files and use a name convention to s…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 /test/ssl/test.pid
 /test/ssl/TestCA1/
 /etc/pgbouncer.ini
+/var
 etc/pgbouncer.ini
 configure.ac
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -21,11 +21,10 @@
 /test/ssl/test.log
 /test/ssl/test.pid
 /test/ssl/TestCA1/
-
+/etc/pgbouncer.ini
 etc/pgbouncer.ini
 configure.ac
 .DS_Store
-
 *.html
 *.xml
 *.exe

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -10,6 +10,7 @@
 ;;   pool_size= reserve_pool= max_db_connections=
 ;;   pool_mode= connect_query= application_name=
 [databases]
+mydb = host=127.0.0.1 port=5432 dbname=mydb
 
 ;; foodb over Unix socket
 ;foodb =
@@ -113,7 +114,7 @@ listen_port = 6432
 
 ;; any, trust, plain, md5, cert, hba, pam
 auth_type = trust
-auth_file = /etc/pgbouncer/userlist.txt
+auth_file = etc/userlist.txt
 
 ;; Path to HBA-style auth config
 ;auth_hba_file =
@@ -128,9 +129,11 @@ auth_file = /etc/pgbouncer/userlist.txt
 
 ;; comma-separated list of users who are allowed to change settings
 ;admin_users = user2, someadmin, otheradmin
+admin_users = user
 
 ;; comma-separated list of users who are just allowed to use SHOW command
 ;stats_users = stats, root
+stats_users = user
 
 ;;;
 ;;; Pooler personality questions
@@ -230,7 +233,7 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; Log incoming client packets
 ;; Will decrease throughput by at least 15%, depending on disk speed.
 ;; Useful for mirroring traffic.
-log_packets = 0
+log_packets = 1
 log_packets_file = /tmp/pktlog
 
 ;;;

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -10,7 +10,6 @@
 ;;   pool_size= reserve_pool= max_db_connections=
 ;;   pool_mode= connect_query= application_name=
 [databases]
-mydb = host=127.0.0.1 port=5432 dbname=mydb
 
 ;; foodb over Unix socket
 ;foodb =
@@ -114,7 +113,7 @@ listen_port = 6432
 
 ;; any, trust, plain, md5, cert, hba, pam
 auth_type = trust
-auth_file = etc/userlist.txt
+auth_file = /etc/pgbouncer/userlist.txt
 
 ;; Path to HBA-style auth config
 ;auth_hba_file =
@@ -231,7 +230,7 @@ auth_file = etc/userlist.txt
 ;; Log incoming client packets
 ;; Will decrease throughput by at least 15%, depending on disk speed.
 ;; Useful for mirroring traffic.
-log_packets = 1
+log_packets = 0
 log_packets_file = /tmp/pktlog
 
 ;;;

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -43,8 +43,8 @@ mydb = host=127.0.0.1 port=5432 dbname=mydb
 ;;; Administrative settings
 ;;;
 
-logfile = /var/log/pgbouncer/pgbouncer.log
-pidfile = /var/run/pgbouncer/pgbouncer.pid
+logfile = var/log/pgbouncer/pgbouncer.log
+pidfile = var/run/pgbouncer/pgbouncer.pid
 
 ;;;
 ;;; Where to wait for clients

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -10,6 +10,7 @@
 ;;   pool_size= reserve_pool= max_db_connections=
 ;;   pool_mode= connect_query= application_name=
 [databases]
+mydb = host=127.0.0.1 port=5432 dbname=mydb
 
 ;; foodb over Unix socket
 ;foodb =
@@ -113,7 +114,7 @@ listen_port = 6432
 
 ;; any, trust, plain, md5, cert, hba, pam
 auth_type = trust
-auth_file = /etc/pgbouncer/userlist.txt
+auth_file = etc/userlist.txt
 
 ;; Path to HBA-style auth config
 ;auth_hba_file =
@@ -230,7 +231,7 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; Log incoming client packets
 ;; Will decrease throughput by at least 15%, depending on disk speed.
 ;; Useful for mirroring traffic.
-log_packets = 0
+log_packets = 1
 log_packets_file = /tmp/pktlog
 
 ;;;

--- a/etc/userlist.txt
+++ b/etc/userlist.txt
@@ -1,3 +1,1 @@
-"marko" "asdasd"
-"postgres" "asdasd"
-"pgbouncer" "fake"
+"user" "pass"

--- a/src/logging.c
+++ b/src/logging.c
@@ -305,11 +305,13 @@ static void log_flush_buffer(void) {
   snprintf(next_fname_available, strlen(cf_log_packets_file)+5, "%s.%03d", cf_log_packets_file, file_id);
 
   /* Check both files */
+  /*
   if (!log_ensure_file_dont_exist(next_fname))
     return;
 
   if (!log_ensure_file_dont_exist(next_fname_available))
     return;
+  */
 
   fd = open(next_fname, O_EXCL | O_APPEND | O_CREAT | O_WRONLY, S_IWUSR | S_IRUSR);
   if (fd == -1) {

--- a/src/logging.c
+++ b/src/logging.c
@@ -181,16 +181,6 @@ void log_connect_to_buffer(bool connected, PgSocket *client) {
   if (!log_ensure_buffer_space(sizeof(net_client_id) + sizeof(net_query_interval) + sizeof(char) + pkt_len))
     return;
 
-  if (client->last_pkt > 0 && !connected) {
-    usec_t query_interval_usec = get_cached_time() - client->last_pkt;
-
-    if (query_interval_usec > UINT32_MAX) {
-      query_interval = UINT32_MAX; /* up to about an hour between queries */
-    } else {
-      query_interval = (uint32_t)query_interval_usec;
-    }
-  }
-
   net_query_interval = htonl(query_interval);
 
   memcpy(buf + len, &net_client_id, sizeof(net_client_id));

--- a/src/logging.c
+++ b/src/logging.c
@@ -181,7 +181,7 @@ void log_connect_to_buffer(bool connected, PgSocket *client) {
     return;
 
   log_info("log_pkt_to_buffer: log_ensure_buffer_space");
-  if (!log_ensure_buffer_space(sizeof(net_client_id) + sizeof(net_query_interval) + sizeof(char) + pkt_len) + sizeof(uint8_t))
+  if (!log_ensure_buffer_space(sizeof(net_client_id) + sizeof(net_query_interval) + sizeof(char) + pkt_len + sizeof(uint8_t)))
     return;
 
   net_query_interval = htonl(query_interval);

--- a/src/logging.c
+++ b/src/logging.c
@@ -175,34 +175,34 @@ void log_connect_to_buffer(bool connected, PgSocket *client) {
            pkt_len = sizeof(uint8_t) + sizeof(uint32_t),
            net_pkt_len = htonl(pkt_len);
 
-  log_info("log_connect_to_buffer");
+  log_debug("log_connect_to_buffer");
 
   if (cf_shutdown)
     return;
 
-  log_info("log_pkt_to_buffer: log_ensure_buffer_space");
+  log_debug("log_pkt_to_buffer: log_ensure_buffer_space");
   if (!log_ensure_buffer_space(sizeof(net_client_id) + sizeof(net_query_interval) + sizeof(char) + pkt_len + sizeof(uint8_t)))
     return;
 
   net_query_interval = htonl(query_interval);
 
-  log_info("log_pkt_to_buffer: client_id");
+  log_debug("log_pkt_to_buffer: client_id");
   memcpy(buf + len, &net_client_id, sizeof(net_client_id));
   len += sizeof(net_client_id);
 
-  log_info("log_pkt_to_buffer: query_interval");
+  log_debug("log_pkt_to_buffer: query_interval");
   memcpy(buf + len, &net_query_interval, sizeof(net_query_interval));
   len += sizeof(net_query_interval);
 
-  log_info("log_pkt_to_buffer: connect_char");
+  log_debug("log_pkt_to_buffer: connect_char");
   memcpy(buf + len, &connect_char, sizeof(char));
   len += sizeof(char);
 
-  log_info("log_pkt_to_buffer: pkt_len");
+  log_debug("log_pkt_to_buffer: pkt_len");
   memcpy(buf + len, &net_pkt_len, sizeof(net_pkt_len));
   len += sizeof(net_pkt_len);
 
-  log_info("log_pkt_to_buffer: connected");
+  log_debug("log_pkt_to_buffer: connected");
   memcpy(buf + len, &connected, sizeof(uint8_t));
   len += sizeof(uint8_t);
 }
@@ -214,13 +214,13 @@ void log_pkt_to_buffer(PktHdr *pkt, PgSocket *client) {
   uint32_t net_client_id = htonl(client->client_id),
            query_interval = 0, net_query_interval;
 
-  log_info("log_pkt_to_buffer");
+  log_debug("log_pkt_to_buffer");
 
   /* If the bouncer is shutting down, the buffer is gone. */
   if (cf_shutdown)
     return;
 
-  log_info("log_pkt_to_buffer: checking for incomplete_pkt");
+  log_debug("log_pkt_to_buffer: checking for incomplete_pkt");
   if (incomplete_pkt(pkt))
     return;
 
@@ -246,13 +246,13 @@ void log_pkt_to_buffer(PktHdr *pkt, PgSocket *client) {
    * pkt->len = packet size
    * + 16 bytes of metadata
    */
-  log_info("log_pkt_to_buffer: log_ensure_buffer_space");
+  log_debug("log_pkt_to_buffer: log_ensure_buffer_space");
 
   if (!log_ensure_buffer_space(sizeof(net_client_id) + sizeof(net_query_interval) + pkt->len))
     return;
 
   /* record intervals between packets */
-  log_info("log_pkt_to_buffer: calc interval");
+  log_debug("log_pkt_to_buffer: calc interval");
 
   if (client->last_pkt > 0) {
     usec_t query_interval_usec = get_cached_time() - client->last_pkt;
@@ -279,16 +279,16 @@ void log_pkt_to_buffer(PktHdr *pkt, PgSocket *client) {
    *             first byte of the packet is the type
    *             next 4 bytes of the packet are the length
    */
-  log_info("log_pkt_to_buffer: writing net_client_id");
+  log_debug("log_pkt_to_buffer: writing net_client_id");
 
   memcpy(buf + len, &net_client_id, sizeof(net_client_id));
   len += sizeof(net_client_id);
 
-  log_info("log_pkt_to_buffer: writing net_query_interval");
+  log_debug("log_pkt_to_buffer: writing net_query_interval");
   memcpy(buf + len, &net_query_interval, sizeof(net_query_interval));
   len += sizeof(net_query_interval);
 
-  log_info("log_pkt_to_buffer: writing pkt data");
+  log_debug("log_pkt_to_buffer: writing pkt data");
   memcpy(buf + len, pkt->data.data, pkt->len);
   len += pkt->len;
 }
@@ -385,7 +385,7 @@ static void log_flush_buffer(void) {
   fsync(fd);
   close(fd);
 
-  // log_info("Flushed %lu bytes to packet log file: %s", len, next_fname);
+  // log_debug("Flushed %lu bytes to packet log file: %s", len, next_fname);
 
   /* Clear the buffer since it's an append buffer */
   memset(buf, 0, len);

--- a/src/logging.c
+++ b/src/logging.c
@@ -175,26 +175,34 @@ void log_connect_to_buffer(bool connected, PgSocket *client) {
            pkt_len = sizeof(uint8_t) + sizeof(uint32_t),
            net_pkt_len = htonl(pkt_len);
 
+  log_info("log_connect_to_buffer");
+
   if (cf_shutdown)
     return;
 
-  if (!log_ensure_buffer_space(sizeof(net_client_id) + sizeof(net_query_interval) + sizeof(char) + pkt_len))
+  log_info("log_pkt_to_buffer: log_ensure_buffer_space");
+  if (!log_ensure_buffer_space(sizeof(net_client_id) + sizeof(net_query_interval) + sizeof(char) + pkt_len) + sizeof(uint8_t))
     return;
 
   net_query_interval = htonl(query_interval);
 
+  log_info("log_pkt_to_buffer: client_id");
   memcpy(buf + len, &net_client_id, sizeof(net_client_id));
   len += sizeof(net_client_id);
 
+  log_info("log_pkt_to_buffer: query_interval");
   memcpy(buf + len, &net_query_interval, sizeof(net_query_interval));
   len += sizeof(net_query_interval);
 
+  log_info("log_pkt_to_buffer: connect_char");
   memcpy(buf + len, &connect_char, sizeof(char));
   len += sizeof(char);
 
+  log_info("log_pkt_to_buffer: pkt_len");
   memcpy(buf + len, &net_pkt_len, sizeof(net_pkt_len));
   len += sizeof(net_pkt_len);
 
+  log_info("log_pkt_to_buffer: connected");
   memcpy(buf + len, &connected, sizeof(uint8_t));
   len += sizeof(uint8_t);
 }
@@ -206,8 +214,14 @@ void log_pkt_to_buffer(PktHdr *pkt, PgSocket *client) {
   uint32_t net_client_id = htonl(client->client_id),
            query_interval = 0, net_query_interval;
 
+  log_info("log_pkt_to_buffer");
+
   /* If the bouncer is shutting down, the buffer is gone. */
   if (cf_shutdown)
+    return;
+
+  log_info("log_pkt_to_buffer: checking for incomplete_pkt");
+  if (incomplete_pkt(pkt))
     return;
 
   /* Log only supported packets.
@@ -232,10 +246,14 @@ void log_pkt_to_buffer(PktHdr *pkt, PgSocket *client) {
    * pkt->len = packet size
    * + 16 bytes of metadata
    */
+  log_info("log_pkt_to_buffer: log_ensure_buffer_space");
+
   if (!log_ensure_buffer_space(sizeof(net_client_id) + sizeof(net_query_interval) + pkt->len))
     return;
 
   /* record intervals between packets */
+  log_info("log_pkt_to_buffer: calc interval");
+
   if (client->last_pkt > 0) {
     usec_t query_interval_usec = get_cached_time() - client->last_pkt;
 
@@ -261,12 +279,16 @@ void log_pkt_to_buffer(PktHdr *pkt, PgSocket *client) {
    *             first byte of the packet is the type
    *             next 4 bytes of the packet are the length
    */
+  log_info("log_pkt_to_buffer: writing net_client_id");
+
   memcpy(buf + len, &net_client_id, sizeof(net_client_id));
   len += sizeof(net_client_id);
 
+  log_info("log_pkt_to_buffer: writing net_query_interval");
   memcpy(buf + len, &net_query_interval, sizeof(net_query_interval));
   len += sizeof(net_query_interval);
 
+  log_info("log_pkt_to_buffer: writing pkt data");
   memcpy(buf + len, pkt->data.data, pkt->len);
   len += pkt->len;
 }

--- a/src/logging.c
+++ b/src/logging.c
@@ -313,11 +313,16 @@ static void log_flush_buffer(void) {
   snprintf(next_fname_available, strlen(cf_log_packets_file)+5, "%s.%03d", cf_log_packets_file, file_id);
 
   /* Check both files */
+  /*
+  This is commented to allow pgbouncer to overwrite existing files
+  It means we may lose packets, but we guarantee the buffer is being flushed (other wise it will be kept full and stop logging anyways)
+
   if (!log_ensure_file_dont_exist(next_fname))
     return;
 
   if (!log_ensure_file_dont_exist(next_fname_available))
     return;
+  */
 
   fd = open(next_fname, O_EXCL | O_APPEND | O_CREAT | O_WRONLY, S_IWUSR | S_IRUSR);
   if (fd == -1) {

--- a/src/logging.c
+++ b/src/logging.c
@@ -252,7 +252,7 @@ void log_pkt_to_buffer(PktHdr *pkt, PgSocket *client) {
  */
 static bool log_ensure_buffer_space(uint32_t n) {
   if (len + n > LOG_BUFFER_SIZE) {
-    log_info("Warning - Disabled packet logging, buffer full");
+    log_info("Warning - Disabled packet logging, buffer full - current buffer size: %zu, bytes required: %u", len, n);
     cf_log_packets = 0;
     log_shutdown();
     return false;

--- a/src/logging.c
+++ b/src/logging.c
@@ -67,7 +67,7 @@ static const char *reload_command = "RELOAD";
 static const char connect_char = '!';
 
 /* Flush packets 10 times per second - every 100ms */
-static struct timeval buffer_drain_period = {0, USEC / 100};
+static struct timeval buffer_drain_period = {0, USEC / 10};
 static struct event buffer_drain_ev;
 
 /* The buffer */

--- a/src/logging.c
+++ b/src/logging.c
@@ -66,8 +66,8 @@ static uint16_t file_id = 0;
 static const char *reload_command = "RELOAD";
 static const char connect_char = '!';
 
-/* Flush packets 10 times per second - every 100ms */
-static struct timeval buffer_drain_period = {0, USEC / 10};
+/* Flush packets 4 times per second - every 250ms */
+static struct timeval buffer_drain_period = {0, USEC / 4};
 static struct event buffer_drain_ev;
 
 /* The buffer */

--- a/src/logging.c
+++ b/src/logging.c
@@ -326,7 +326,7 @@ static void log_flush_buffer(void) {
   fsync(fd);
   close(fd);
 
-  log_info("Flushed %lu bytes to packet log file: %s", len, next_fname);
+  // log_info("Flushed %lu bytes to packet log file: %s", len, next_fname);
 
   /* Clear the buffer since it's an append buffer */
   memset(buf, 0, len);

--- a/src/logging.c
+++ b/src/logging.c
@@ -66,8 +66,8 @@ static uint16_t file_id = 0;
 static const char *reload_command = "RELOAD";
 static const char connect_char = '!';
 
-/* Flush packets 20 times per second - every 50ms */
-static struct timeval buffer_drain_period = {0, USEC / 20};
+/* Flush packets 10 times per second - every 100ms */
+static struct timeval buffer_drain_period = {0, USEC / 100};
 static struct event buffer_drain_ev;
 
 /* The buffer */

--- a/src/logging.c
+++ b/src/logging.c
@@ -252,9 +252,13 @@ void log_pkt_to_buffer(PktHdr *pkt, PgSocket *client) {
  */
 static bool log_ensure_buffer_space(uint32_t n) {
   if (len + n > LOG_BUFFER_SIZE) {
-    log_info("Warning - Disabled packet logging, buffer full - current buffer size: %zu, bytes required: %u", len, n);
+    log_info("Warning - Buffer full - current buffer size: %zu, bytes required: %u", len, n);
+    /*
+    don't disable logging
+
     cf_log_packets = 0;
     log_shutdown();
+    */
     return false;
   }
   return true;
@@ -268,9 +272,13 @@ static bool log_ensure_file_dont_exist(char *file) {
   if (stat(file, &info) != -1) {
     char time[50];
     strftime(time, 50, "%Y-%m-%d %H:%M:%S", localtime(&info.st_mtime));
-    log_info("Warning - Disabled packet logging, packet log file exists: %s, size: %lld bytes, modified_at: %s", file, info.st_size, time);
+    log_info("Warning - Packet log file exists: %s, size: %lld bytes, modified_at: %s", file, info.st_size, time);
+    /*
+    don't disable logging
+    
     cf_log_packets = 0;
     log_shutdown();
+    */    
     return false;
   }
   return true;
@@ -305,13 +313,11 @@ static void log_flush_buffer(void) {
   snprintf(next_fname_available, strlen(cf_log_packets_file)+5, "%s.%03d", cf_log_packets_file, file_id);
 
   /* Check both files */
-  /*
   if (!log_ensure_file_dont_exist(next_fname))
     return;
 
   if (!log_ensure_file_dont_exist(next_fname_available))
     return;
-  */
 
   fd = open(next_fname, O_EXCL | O_APPEND | O_CREAT | O_WRONLY, S_IWUSR | S_IRUSR);
   if (fd == -1) {


### PR DESCRIPTION
this change make file writing more defensive by:
- introducing a file id suffix which allow us to know if a file have been skipped
- using a file name convention to signal to consumer (i.e. replayer) to know the file is ready to use, so the replayer don't need to bother analysing in-flight files which may lead to corruption
- eliminating lock needs, since now we use 256 target files instead of just one